### PR TITLE
fix(chapters): rename form to chapters

### DIFF
--- a/packages/chapters/src/templates/index-page.js
+++ b/packages/chapters/src/templates/index-page.js
@@ -10,7 +10,7 @@ export const IndexPageTemplate = ({ hero, modal }) => {
       <Hero title={hero.title} />
       <div dangerouslySetInnerHTML={{ __html: hero.subtitle }} />
       <Content>
-        <Form name="volunteers" modal={modal} />
+        <Form name="chapters" modal={modal} />
       </Content>
       <ReadProgress />
     </>


### PR DESCRIPTION
**What:** rename form to chapters

**Why:** this was left from copying the code from volunteers

**How:**

- rename form from **volunteers** to **chapters**