### PR TITLE
fix(Modal): callback is called onHide instead of onClose

### DIFF
--- a/packages/chapters/src/components/Form/index.js
+++ b/packages/chapters/src/components/Form/index.js
@@ -21,9 +21,9 @@ function encode(data) {
     .join('&')
 }
 
-const AfterSubmitModal = ({ show, onClose, onPrimaryClick, copy }) => {
+const AfterSubmitModal = ({ show, onHide, onPrimaryClick, copy }) => {
   return (
-    <Modal show={show}>
+    <Modal show={show} onHide={onHide}>
       <Modal.Header closeButton>
         <Modal.Title>{copy.title}</Modal.Title>
       </Modal.Header>
@@ -31,7 +31,7 @@ const AfterSubmitModal = ({ show, onClose, onPrimaryClick, copy }) => {
       <Modal.Body>{copy.content}</Modal.Body>
 
       <Modal.Footer>
-        <Button variant="secondary" onClick={() => onClose()}>
+        <Button variant="secondary" onClick={() => onHide()}>
           Close
         </Button>
         <Button variant="primary" onClick={() => onPrimaryClick()}>
@@ -44,7 +44,7 @@ const AfterSubmitModal = ({ show, onClose, onPrimaryClick, copy }) => {
 
 AfterSubmitModal.propTypes = {
   show: PropTypes.bool.isRequired,
-  onClose: PropTypes.func,
+  onHide: PropTypes.func,
   onPrimaryClick: PropTypes.func,
   copy: PropTypes.shape({
     title: PropTypes.string,
@@ -54,7 +54,7 @@ AfterSubmitModal.propTypes = {
 }
 
 AfterSubmitModal.defaultProps = {
-  onClose: _.noop,
+  onHide: _.noop,
   onPrimaryClick: _.noop,
   copy: { title: '', content: '', actionButton: 'Ok' },
 }
@@ -125,7 +125,7 @@ const VolunteerForm = ({ name, modal }) => {
     <>
       <AfterSubmitModal
         show={show}
-        onClose={handleModalClose}
+        onHide={handleModalClose}
         onPrimaryClick={afterSubmitRedirect}
         copy={modal}
       />

--- a/packages/common/components/Footer/index.js
+++ b/packages/common/components/Footer/index.js
@@ -125,6 +125,7 @@ const Footer = () => {
                 <a
                   href="https://community.debtcollective.org/tos"
                   target="_blank"
+                  rel="noopener noreferrer"
                 >
                   Terms and Conditions
                 </a>
@@ -138,7 +139,11 @@ const Footer = () => {
           <div className="col">
             <div className="footer__netlify-logo">
               Hosted on
-              <a href="https://www.netlify.com/" target="_blank">
+              <a
+                href="https://www.netlify.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 <img
                   src="https://www.netlify.com/img/press/logos/full-logo-dark-simple.svg"
                   alt="netlify logo"

--- a/packages/volunteer/src/components/Form/index.js
+++ b/packages/volunteer/src/components/Form/index.js
@@ -20,9 +20,9 @@ function encode(data) {
     .join('&')
 }
 
-const AfterSubmitModal = ({ show, onClose, onPrimaryClick, copy }) => {
+const AfterSubmitModal = ({ show, onHide, onPrimaryClick, copy }) => {
   return (
-    <Modal show={show}>
+    <Modal show={show} onHide={onHide}>
       <Modal.Header closeButton>
         <Modal.Title>{copy.title}</Modal.Title>
       </Modal.Header>
@@ -30,7 +30,7 @@ const AfterSubmitModal = ({ show, onClose, onPrimaryClick, copy }) => {
       <Modal.Body>{copy.content}</Modal.Body>
 
       <Modal.Footer>
-        <Button variant="secondary" onClick={() => onClose()}>
+        <Button variant="secondary" onClick={() => onHide()}>
           Close
         </Button>
         <Button variant="primary" onClick={() => onPrimaryClick()}>
@@ -43,7 +43,7 @@ const AfterSubmitModal = ({ show, onClose, onPrimaryClick, copy }) => {
 
 AfterSubmitModal.propTypes = {
   show: PropTypes.bool.isRequired,
-  onClose: PropTypes.func,
+  onHide: PropTypes.func,
   onPrimaryClick: PropTypes.func,
   copy: PropTypes.shape({
     title: PropTypes.string,
@@ -53,7 +53,7 @@ AfterSubmitModal.propTypes = {
 }
 
 AfterSubmitModal.defaultProps = {
-  onClose: _.noop,
+  onHide: _.noop,
   onPrimaryClick: _.noop,
   copy: { title: '', content: '', actionButton: 'Ok' },
 }
@@ -124,7 +124,7 @@ const VolunteerForm = ({ name, modal }) => {
     <>
       <AfterSubmitModal
         show={show}
-        onClose={handleModalClose}
+        onHide={handleModalClose}
         onPrimaryClick={afterSubmitRedirect}
         copy={modal}
       />


### PR DESCRIPTION
**What:** callback is called onHide instead of onClose

source https://react-bootstrap.github.io/components/modal/#modal-props

**Why:** Close https://app.asana.com/0/1159164196409156/1170548667903353

**How:**

- change `onClose` to `onHide`
