### PR TITLE
Improve a11y on forms

### DIFF
--- a/packages/chapters/package.json
+++ b/packages/chapters/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "author": "@debtcollective",
   "dependencies": {
-    "@debtcollective/dc-footer-component": "^0.2.3",
+    "@debtcollective/dc-footer-component": "^0.2.4",
     "bootstrap": "^4.3.1",
     "classnames": "2.2.6",
     "common": "^1.0.1",

--- a/packages/chapters/src/components/Form/index.js
+++ b/packages/chapters/src/components/Form/index.js
@@ -141,7 +141,7 @@ const VolunteerForm = ({ name, modal }) => {
         onSubmit={handleSubmit(onSubmit)}
       >
         <div className="form-section">
-          <h3 className="mb-3">Personal information</h3>
+          <h2 className="mb-3">Personal information</h2>
           <Form.Group controlId="fullName">
             <Form.Label>Full name{required}</Form.Label>
             <Form.Control
@@ -263,7 +263,7 @@ const VolunteerForm = ({ name, modal }) => {
         </div>
 
         <div className="form-section mt-4">
-          <h3>Share a bit about your background and interest</h3>
+          <h2>Share a bit about your background and interest</h2>
           <Form.Group controlId="locationToFocusOn">
             <Form.Label>
               What is the town/city/state/campus/workplace/region you’d like to
@@ -457,7 +457,7 @@ const VolunteerForm = ({ name, modal }) => {
           </Form.Group>
         </div>
         <div className="form-section mt-4">
-          <h3 className="mb-3">Social networks</h3>
+          <h2 className="mb-3">Social networks</h2>
           <Form.Group controlId="twitter">
             <InputGroup className="mb-3">
               <InputGroup.Prepend>
@@ -481,7 +481,7 @@ const VolunteerForm = ({ name, modal }) => {
           <Form.Group controlId="facebook">
             <InputGroup className="mb-3">
               <InputGroup.Prepend>
-                <InputGroup.Text id="basic-addon1">
+                <InputGroup.Text id="basic-addon2">
                   facebook.com/
                 </InputGroup.Text>
               </InputGroup.Prepend>
@@ -501,7 +501,7 @@ const VolunteerForm = ({ name, modal }) => {
           <Form.Group controlId="instagram">
             <InputGroup className="mb-3">
               <InputGroup.Prepend>
-                <InputGroup.Text id="basic-addon1">
+                <InputGroup.Text id="basic-addon3">
                   instagram.com/
                 </InputGroup.Text>
               </InputGroup.Prepend>

--- a/packages/common/components/FormFields.js
+++ b/packages/common/components/FormFields.js
@@ -141,6 +141,7 @@ export const CountryDropdownField = ({
   return (
     <CountryDropdown
       className={cssClasses}
+      aria-label="Select a country"
       name={name}
       value={country}
       onChange={value => {
@@ -184,6 +185,7 @@ export const RegionDropdownField = ({
       className={cssClasses}
       name={name}
       country={country}
+      aria-label="Select a state"
       value={region}
       onChange={value => {
         setRegion(value)

--- a/packages/common/components/Header/index.js
+++ b/packages/common/components/Header/index.js
@@ -58,8 +58,8 @@ const Header = () => {
                     width="100%"
                   />
                 </Link>
-                <div className="d-none d-xl-flex">
-                  <ul className="nav align-items-center" role="navigation">
+                <nav className="d-none d-xl-flex">
+                  <ul className="nav align-items-center">
                     <li className="nav-item">
                       <a
                         className="nav-link"
@@ -101,7 +101,7 @@ const Header = () => {
                       </a>
                     </li>
                   </ul>
-                </div>
+                </nav>
               </div>
             </div>
             <div className="col-3 col-lg-3">
@@ -142,8 +142,8 @@ const Header = () => {
         </div>
       </header>
       <Collapse in={open}>
-        <div id="slider-nav" className="slider-nav d-xl-none">
-          <ul className="nav flex-column" role="navigation">
+        <nav id="slider-nav" className="slider-nav d-xl-none">
+          <ul className="nav flex-column">
             <li className="nav-item">
               <a
                 className="nav-link"
@@ -185,7 +185,7 @@ const Header = () => {
               </a>
             </li>
           </ul>
-        </div>
+        </nav>
       </Collapse>
     </>
   )

--- a/packages/common/components/Layout.js
+++ b/packages/common/components/Layout.js
@@ -28,7 +28,7 @@ const Layout = ({
       />
       <Header />
       <div id="main" className="main">
-        <div className="container">{children}</div>
+        <main className="container">{children}</main>
       </div>
       <dc-footer />
     </>

--- a/packages/volunteer/package.json
+++ b/packages/volunteer/package.json
@@ -5,7 +5,7 @@
   "version": "1.1.3",
   "author": "@debtcollective",
   "dependencies": {
-    "@debtcollective/dc-footer-component": "^0.2.3",
+    "@debtcollective/dc-footer-component": "^0.2.4",
     "bootstrap": "^4.3.1",
     "classnames": "2.2.6",
     "common": "^1.0.1",

--- a/packages/volunteer/src/components/Form/index.js
+++ b/packages/volunteer/src/components/Form/index.js
@@ -137,7 +137,7 @@ const VolunteerForm = ({ name, modal }) => {
         onSubmit={handleSubmit(onSubmit)}
       >
         <div className="form-section">
-          <h3 className="mb-3">Personal information</h3>
+          <h2 className="mb-3">Personal information</h2>
           <Form.Group controlId="fullName">
             <Form.Label>Full name{required}</Form.Label>
             <Form.Control
@@ -356,7 +356,7 @@ const VolunteerForm = ({ name, modal }) => {
         </div>
 
         <div className="form-section mt-4">
-          <h3>Skills</h3>
+          <h2>Skills</h2>
           <Form.Group controlId="skills">
             <Form.Label>I have background/skills with:</Form.Label>
             {skills.map((skill) => (
@@ -395,7 +395,7 @@ const VolunteerForm = ({ name, modal }) => {
         </div>
 
         <div className="form-section mt-4">
-          <h3 className="mb-3">Social networks</h3>
+          <h2 className="mb-3">Social networks</h2>
           <Form.Group controlId="twitter">
             <InputGroup className="mb-3">
               <InputGroup.Prepend>
@@ -419,7 +419,7 @@ const VolunteerForm = ({ name, modal }) => {
           <Form.Group controlId="facebook">
             <InputGroup className="mb-3">
               <InputGroup.Prepend>
-                <InputGroup.Text id="basic-addon1">
+                <InputGroup.Text id="basic-addon2">
                   facebook.com/
                 </InputGroup.Text>
               </InputGroup.Prepend>
@@ -439,7 +439,7 @@ const VolunteerForm = ({ name, modal }) => {
           <Form.Group controlId="instagram">
             <InputGroup className="mb-3">
               <InputGroup.Prepend>
-                <InputGroup.Text id="basic-addon1">
+                <InputGroup.Text id="basic-addon3">
                   instagram.com/
                 </InputGroup.Text>
               </InputGroup.Prepend>

--- a/packages/volunteer/src/components/Form/index.js
+++ b/packages/volunteer/src/components/Form/index.js
@@ -275,7 +275,6 @@ const VolunteerForm = ({ name, modal }) => {
         </div>
 
         <div className="form-section mt-4">
-          <h3>Share a bit about your background and interest</h3>
           <Form.Group controlId="locationToFocusOn">
             <Form.Label>
               What is the town/city/state/campus/workplace/region you’d like to

--- a/packages/volunteer/src/pages/index.md
+++ b/packages/volunteer/src/pages/index.md
@@ -5,8 +5,6 @@ hero:
   subtitle: |-
     <p class="text-center mb-0 mt-2">
       Submit this form if you’d like to get involved in The Debt Collective. Someone will be in touch with you soon!
-    </p> <p class="text-center mb-0">
-      If you are looking to start a local group/collective, please email <a href="mailto:winter@debtcollective.org">winter@debtcollective.org</a>.
     </p> <p class="text-center mb-0 mt-2">
       <i>We will keep your information as secure and private as possible.</i>
     </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,10 +895,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@debtcollective/dc-footer-component@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@debtcollective/dc-footer-component/-/dc-footer-component-0.2.3.tgz#33f5051cf88b2da91da5c71ad73af14b20e325c8"
-  integrity sha512-vy9R3ofU/ylzoVY4Noo1IbEGmcxxTWL+ujNtF2vYcWt8fPsVwui8NPFsVx1Q2t7Jrz29ON6rWO2kYT9k2rzWZQ==
+"@debtcollective/dc-footer-component@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@debtcollective/dc-footer-component/-/dc-footer-component-0.2.4.tgz#9dc07bd191f694c9168322f2f631ba267fc8499b"
+  integrity sha512-NYuKSAOFbcf3FlCFJMbqTjbjpZIPg8z5eLrwGayryGVgzPDtZE5cJevp6HXI8123iOJrehxP/bqYsXe4ytIeHw==
   dependencies:
     "@stencil/core" "^2.0.1"
 


### PR DESCRIPTION
**What:**
- Remove text `If you are looking to start a local group/collective...` from subtitle and `Share a bit about your background...` from a form section ([requested by Umme](https://debtcollective.slack.com/archives/CQ3V1F7C2/p1612915186130900))
- Improve a11y on the volunteer form
- Improve a11y on the chapters form
 
**Why:**
Relates to: https://app.asana.com/0/1159164196409129/1199894650575790/f

**How:**
- Wrapping the content into a `main` tag
- Using unique id's for HTML elements
- Use the correct heading levels (replace h3 for h2)
- Include `aria-label` on dropdowns
- Remove `role="navigation"` and use a `nav` tag instead

#### Media
https://www.loom.com/share/520dfe2e780c4a3293d88af99d7b884b
https://www.loom.com/share/634836d528fd4a76add4adebcdfc1de9